### PR TITLE
Re-enable shulker opening with target block and fix click bleeding

### DIFF
--- a/src/main/java/net/kyrptonaught/quickshulker/QuickShulkerMod.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/QuickShulkerMod.java
@@ -34,7 +34,7 @@ public class QuickShulkerMod implements ModInitializer, RegisterQuickShulker {
             ItemStack stack = player.getStackInHand(hand);
             if (!world.isClient) {
                 if (QuickShulkerMod.getConfig().rightClickToOpen) {
-                    if (Util.isOpenableItem(stack) && Util.canOpenInHand(stack) && !Util.isBlockBlockingQuickOpen(world, player)) {
+                    if (Util.isOpenableItem(stack) && Util.canOpenInHand(stack)) {
                         if (hand == Hand.MAIN_HAND)
                             Util.openItem(player, 0, player.getInventory().selectedSlot);
                         else Util.openItem(player, 0, PlayerInventory.OFF_HAND_SLOT);

--- a/src/main/java/net/kyrptonaught/quickshulker/api/Util.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/api/Util.java
@@ -3,7 +3,6 @@ package net.kyrptonaught.quickshulker.api;
 import net.kyrptonaught.quickshulker.ItemInventoryContainer;
 import net.kyrptonaught.quickshulker.QuickShulkerMod;
 import net.kyrptonaught.quickshulker.network.OpenInventoryPacket;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
@@ -11,9 +10,6 @@ import net.minecraft.network.packet.s2c.play.CloseScreenS2CPacket;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.ScreenHandlerListener;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.util.hit.BlockHitResult;
-import net.minecraft.util.hit.HitResult;
-import net.minecraft.world.World;
 
 public class Util {
 
@@ -35,20 +31,13 @@ public class Util {
         stack.removeSubNbt(QuickShulkerMod.MOD_ID);
         QuickShulkerData qsData = QuickOpenableRegistry.getQuickie(stack.getItem());
         if (qsData != null) {
-            if (isBlockBlockingQuickOpen(player.getWorld(), player))
-                return;
             qsData.openConsumer.accept(player, stack);
             ((ItemInventoryContainer) player.currentScreenHandler).setUsedSlot(playerInvIndex);
             player.currentScreenHandler.addListener(forceCloseScreenIfNotPresent(player, playerInvIndex, stack));
         }
     }
 
-    public static boolean isBlockBlockingQuickOpen(World world, PlayerEntity player) {
-        HitResult result = player.raycast(4.5, 0, false);
-        return result instanceof BlockHitResult blockHitResult && !player.world.getBlockState(blockHitResult.getBlockPos()).isAir();
-    }
-
-    public static boolean isOpenableItem(ItemStack stack) {
+    public static Boolean isOpenableItem(ItemStack stack) {
         QuickShulkerData qsdata = QuickOpenableRegistry.getQuickie(stack.getItem());
         if (qsdata == null) return false;
         return qsdata.ignoreSingleStackCheck || stack.getCount() <= 1;

--- a/src/main/java/net/kyrptonaught/quickshulker/client/ClientUtil.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/client/ClientUtil.java
@@ -14,7 +14,7 @@ import net.minecraft.screen.slot.Slot;
 public class ClientUtil {
 
     public static boolean CheckAndSend(ItemStack stack, int slot) {
-        if (Util.isOpenableItem(stack) && !Util.isBlockBlockingQuickOpen(MinecraftClient.getInstance().world, MinecraftClient.getInstance().player)) {
+        if (Util.isOpenableItem(stack)) {
             SendOpenPacket(slot);
             return true;
         }

--- a/src/main/java/net/kyrptonaught/quickshulker/mixin/ScreenMixin.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/mixin/ScreenMixin.java
@@ -32,6 +32,8 @@ public abstract class ScreenMixin {
     @Final
     protected ScreenHandler handler;
 
+    @Shadow private boolean cancelNextRelease;
+
     @Inject(method = "init", at = @At("TAIL"))
     private void fixMouse(CallbackInfo ci) {
         if (QuickShulkerMod.lastMouseX != 0 && QuickShulkerMod.lastMouseY != 0) {
@@ -55,14 +57,20 @@ public abstract class ScreenMixin {
     private void QS$mousePressed(double mouseX, double mouseY, int button, CallbackInfoReturnable<Boolean> cir) {
         if (QuickShulkerMod.getConfig().rightClickInv) {
             if (this.handler.getCursorStack().isEmpty() && button == 1 && this.focusedSlot != null && this.focusedSlot.getStack().getCount() == 1) {
-                if (handleTrigger())
+                if (handleTrigger()) {
+                    this.cancelNextRelease = true;
                     cir.setReturnValue(true);
+                    return;
+                }
             }
         }
         if (QuickShulkerMod.getConfig().keybingInInv) {
             if (QuickShulkerModClient.getKeybinding().matches(button, InputUtil.Type.MOUSE)) {
-                if (handleTrigger())
+                if (handleTrigger()) {
+                    this.cancelNextRelease = true;
                     cir.setReturnValue(true);
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
1. Re-enable the opening of shulker boxes when targeting an in-world block
2. Fixes click bleeding through the interface and having shulkers sometimes place in world when clicked from inventory, that sort of things (that may or may not fix the dupe that caused 1. to be disabled in the first place?). 


Fixes #71 
Fixes #63 
Fixes #2
Fixes #16 
Fixes #50 