### PR TITLE
Add quick smithing

### DIFF
--- a/src/main/java/net/kyrptonaught/quickshulker/QuickShulkerMod.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/QuickShulkerMod.java
@@ -8,10 +8,7 @@ import net.kyrptonaught.quickshulker.api.*;
 import net.kyrptonaught.quickshulker.config.ConfigOptions;
 import net.kyrptonaught.quickshulker.network.OpenShulkerPacket;
 import net.kyrptonaught.quickshulker.network.QuickBundlePacket;
-import net.minecraft.block.CraftingTableBlock;
-import net.minecraft.block.EnderChestBlock;
-import net.minecraft.block.ShulkerBoxBlock;
-import net.minecraft.block.StonecutterBlock;
+import net.minecraft.block.*;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.screen.*;
@@ -85,6 +82,14 @@ public class QuickShulkerMod implements ModInitializer, RegisterQuickShulker {
                     .ignoreSingleStackCheck(true)
                     .setOpenAction(((player, stack) -> player.openHandledScreen(new SimpleNamedScreenHandlerFactory((i, playerInventory, playerEntity) ->
                             new StonecutterScreenHandler(i, playerInventory, ScreenHandlerContext.create(player.getEntityWorld(), player.getBlockPos())), Text.translatable("container.stonecutter")))))
+                    .register();
+
+        if (getConfig().quickSmithing)
+            new QuickOpenableRegistry.Builder()
+                    .setItem(SmithingTableBlock.class)
+                    .ignoreSingleStackCheck(true)
+                    .setOpenAction((player, stack) -> player.openHandledScreen(new SimpleNamedScreenHandlerFactory((i, playerInventory, playerEntity) ->
+                            new SmithingScreenHandler(i, playerInventory, ScreenHandlerContext.create(playerEntity.getEntityWorld(), playerEntity.getBlockPos())), Text.translatable("container.upgrade"))))
                     .register();
     }
 }

--- a/src/main/java/net/kyrptonaught/quickshulker/config/ConfigOptions.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/config/ConfigOptions.java
@@ -35,5 +35,7 @@ public class ConfigOptions implements AbstractConfigFile {
     public boolean quickStonecutter = true;
     @Comment("Enable opening EnderChest")
     public boolean quickEChest = true;
+    @Comment("Enable opening Smithing table")
+    public boolean quickSmithing = true;
 
 }

--- a/src/main/java/net/kyrptonaught/quickshulker/config/modmenu/ModMenuIntegration.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/config/modmenu/ModMenuIntegration.java
@@ -46,6 +46,7 @@ public class ModMenuIntegration implements ModMenuApi {
             enabledSection.addConfigItem(new BooleanItem(Text.translatable("key.quickshulker.config.quickCraftingTable"), options.quickCraftingTables, true).setSaveConsumer(value -> options.quickCraftingTables = value).setRequiresRestart());
             enabledSection.addConfigItem(new BooleanItem(Text.translatable("key.quickshulker.config.quickStonecutter"), options.quickStonecutter, true).setSaveConsumer(value -> options.quickStonecutter = value).setRequiresRestart());
             enabledSection.addConfigItem(new BooleanItem(Text.translatable("key.quickshulker.config.quickEChest"), options.quickEChest, true).setSaveConsumer(value -> options.quickEChest = value).setRequiresRestart());
+            enabledSection.addConfigItem(new BooleanItem(Text.translatable("key.quickshulker.config.quickSmithing"), options.quickSmithing, true).setSaveConsumer(value -> options.quickSmithing = value).setRequiresRestart());
 
             return configScreen;
         };

--- a/src/main/java/net/kyrptonaught/quickshulker/mixin/CraftingScreenHandlerMixin.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/mixin/CraftingScreenHandlerMixin.java
@@ -4,24 +4,21 @@ import net.kyrptonaught.quickshulker.ItemInventoryContainer;
 import net.kyrptonaught.quickshulker.api.Util;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.screen.CraftingScreenHandler;
-import net.minecraft.screen.ScreenHandler;
-import net.minecraft.screen.ScreenHandlerType;
-import net.minecraft.screen.StonecutterScreenHandler;
+import net.minecraft.screen.*;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(value = {CraftingScreenHandler.class, StonecutterScreenHandler.class})
+@Mixin(value = {CraftingScreenHandler.class, StonecutterScreenHandler.class, ForgingScreenHandler.class})
 public abstract class CraftingScreenHandlerMixin extends ScreenHandler {
 
     protected CraftingScreenHandlerMixin(@Nullable ScreenHandlerType<?> type, int syncId) {
         super(type, syncId);
     }
 
-    @Inject(method = "canUse", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "canUse(Lnet/minecraft/entity/player/PlayerEntity;)Z", at = @At("HEAD"), cancellable = true)
     public void overrideCanUse(PlayerEntity player, CallbackInfoReturnable<Boolean> cir) {
         if (((ItemInventoryContainer) this).hasItem()) {
             ItemStack stack = player.getInventory().getStack(((ItemInventoryContainer) this).getUsedSlotInPlayerInv());

--- a/src/main/resources/assets/quickshulker/lang/en_us.json
+++ b/src/main/resources/assets/quickshulker/lang/en_us.json
@@ -18,5 +18,6 @@
   "key.quickshulker.config.quickShulkerBox": "Enable opening Shulker Boxes",
   "key.quickshulker.config.quickCraftingTable": "Enable opening Crafting Tables",
   "key.quickshulker.config.quickStonecutter": "Enable opening Stonecutter",
-  "key.quickshulker.config.quickEChest": "Enable opening EnderChest"
+  "key.quickshulker.config.quickEChest": "Enable opening EnderChest",
+  "key.quickshulker.config.quickSmithing": "Enable opening Smithing table"
 }


### PR DESCRIPTION
Add Smithing table to quickies

I noticed that in `QuickShulkerMod.java`, arrow functions inside `SimpleNamedScreenHandlerFactory` use the `player` from `setOpenAction`. Is this intended?