### PR TITLE
Update to latest version - 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,14 +25,14 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation include("net.kyrptonaught:kyrptconfig:1.6.3-1.21.9") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation include("net.kyrptonaught:kyrptconfig:1.6.3-1.21.10") { exclude group: "net.fabricmc.fabric-api" }
 
 	//update modmenu when kyrptconfig is pulling old version
 	modImplementation ("com.terraformersmc:modmenu:16.0.0") { exclude group: "net.fabricmc.fabric-api" }
 
 	//shulkerutils
-	modImplementation 'net.kyrptonaught:shulkerutils:1.0.5-1.21.9'
-	include 'net.kyrptonaught:shulkerutils:1.0.5-1.21.9'
+	modImplementation 'net.kyrptonaught:shulkerutils:1.0.5-1.21.10'
+	include 'net.kyrptonaught:shulkerutils:1.0.5-1.21.10'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -25,14 +25,14 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation include("net.kyrptonaught:kyrptconfig:1.6.1-1.21.4") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation include("net.kyrptonaught:kyrptconfig:1.6.1-1.21.5") { exclude group: "net.fabricmc.fabric-api" }
 
 	//update modmenu when kyrptconfig is pulling old version
-	modImplementation ("com.terraformersmc:modmenu:13.0.0") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation ("com.terraformersmc:modmenu:14.0.1") { exclude group: "net.fabricmc.fabric-api" }
 
 	//shulkerutils
-	modImplementation 'net.kyrptonaught:shulkerutils:1.0.5-1.21.4'
-	include 'net.kyrptonaught:shulkerutils:1.0.5-1.21.4'
+	modImplementation 'net.kyrptonaught:shulkerutils:1.0.5-1.21.5'
+	include 'net.kyrptonaught:shulkerutils:1.0.5-1.21.5'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -25,14 +25,14 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation include("net.kyrptonaught:kyrptconfig:1.6.2-1.21.8") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation include("net.kyrptonaught:kyrptconfig:1.6.3-1.21.9") { exclude group: "net.fabricmc.fabric-api" }
 
 	//update modmenu when kyrptconfig is pulling old version
-	modImplementation ("com.terraformersmc:modmenu:15.0.1") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation ("com.terraformersmc:modmenu:16.0.0") { exclude group: "net.fabricmc.fabric-api" }
 
 	//shulkerutils
-	modImplementation 'net.kyrptonaught:shulkerutils:1.0.5-1.21.8'
-	include 'net.kyrptonaught:shulkerutils:1.0.5-1.21.8'
+	modImplementation 'net.kyrptonaught:shulkerutils:1.0.5-1.21.9'
+	include 'net.kyrptonaught:shulkerutils:1.0.5-1.21.9'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.2-SNAPSHOT'
+	id 'fabric-loom' version '1.10-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -27,14 +27,14 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation include("net.kyrptonaught:kyrptconfig:1.5.4-1.20") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation include("net.kyrptonaught:kyrptconfig:1.5.8-1.20.2") { exclude group: "net.fabricmc.fabric-api" }
 
 	//update modmenu when kyrptconfig is pulling old version
-	modImplementation ("com.terraformersmc:modmenu:7.0.1") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation ("com.terraformersmc:modmenu:8.0.1") { exclude group: "net.fabricmc.fabric-api" }
 
 	//shulkerutils
-	modImplementation 'net.kyrptonaught:shulkerutils:1.0.4-1.19'
-	include 'net.kyrptonaught:shulkerutils:1.0.4-1.19'
+	modImplementation 'net.kyrptonaught:shulkerutils:1.0.5-1.20.2'
+	include 'net.kyrptonaught:shulkerutils:1.0.5-1.20.2'
 }
 
 tasks.withType(JavaCompile).configureEach {
@@ -51,6 +51,10 @@ jar {
 	}
 }
 
+repositories {
+	mavenLocal()
+}
+
 // configure the maven publication
 publishing {
 	publications {
@@ -60,6 +64,7 @@ publishing {
 		}
 	}
 	repositories {
+		mavenLocal()
 		maven {
 			url ='s3://maven.kyrptonaught.dev'
 			credentials(AwsCredentials) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,13 @@
 plugins {
-	id 'fabric-loom' version '1.10-SNAPSHOT'
+	id 'fabric-loom' version '1.15-SNAPSHOT'
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
-
-archivesBaseName = project.archives_base_name
-version = project.mod_version
-group = project.maven_group
-
+base {
+	archivesName = project.archives_base_name
+	version = project.mod_version
+	group = project.maven_group
+}
 
 loom {
 	accessWidenerPath = file("src/main/resources/quickshulker.accesswidener")
@@ -27,27 +25,29 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation include("net.kyrptonaught:kyrptconfig:1.6.1-1.20.5") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation include("net.kyrptonaught:kyrptconfig:1.6.1-1.21.4") { exclude group: "net.fabricmc.fabric-api" }
 
 	//update modmenu when kyrptconfig is pulling old version
-	modImplementation ("com.terraformersmc:modmenu:10.0.0") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation ("com.terraformersmc:modmenu:13.0.0") { exclude group: "net.fabricmc.fabric-api" }
 
 	//shulkerutils
-	modImplementation 'net.kyrptonaught:shulkerutils:1.0.5-1.20.5'
-	include 'net.kyrptonaught:shulkerutils:1.0.5-1.20.5'
+	modImplementation 'net.kyrptonaught:shulkerutils:1.0.5-1.21.4'
+	include 'net.kyrptonaught:shulkerutils:1.0.5-1.21.4'
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 17
+	it.options.release = 21
 }
 
 java {
 	withSourcesJar()
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 }
 
 jar {
 	from("LICENSE") {
-		rename { "${it}_${project.archivesBaseName}" }
+		rename { "${it}_${base.archivesName.get()}" }
 	}
 }
 
@@ -59,7 +59,7 @@ repositories {
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
-			artifactId archivesBaseName
+			artifactId = project.archives_base_name
 			from components.java
 		}
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 	maven { url 'https://maven.fabricmc.net' }
 	maven { url 'https://maven.kyrptonaught.dev' }
 	maven { url "https://maven.terraformersmc.com/releases" }
+	maven { url "https://maven.nucleoid.xyz/" }
 }
 
 dependencies {
@@ -27,14 +28,14 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation include("net.kyrptonaught:kyrptconfig:1.5.8-1.20.2") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation include("net.kyrptonaught:kyrptconfig:1.6.0-1.20.4") { exclude group: "net.fabricmc.fabric-api" }
 
 	//update modmenu when kyrptconfig is pulling old version
-	modImplementation ("com.terraformersmc:modmenu:8.0.1") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation ("com.terraformersmc:modmenu:9.2.0") { exclude group: "net.fabricmc.fabric-api" }
 
 	//shulkerutils
-	modImplementation 'net.kyrptonaught:shulkerutils:1.0.5-1.20.2'
-	include 'net.kyrptonaught:shulkerutils:1.0.5-1.20.2'
+	modImplementation 'net.kyrptonaught:shulkerutils:1.0.5-1.20.4'
+	include 'net.kyrptonaught:shulkerutils:1.0.5-1.20.4'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -25,14 +25,14 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation include("net.kyrptonaught:kyrptconfig:1.6.3-1.21.10") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation include("net.kyrptonaught:kyrptconfig:1.6.4-1.21.11") { exclude group: "net.fabricmc.fabric-api" }
 
 	//update modmenu when kyrptconfig is pulling old version
-	modImplementation ("com.terraformersmc:modmenu:16.0.0") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation ("com.terraformersmc:modmenu:17.0.0-beta.2") { exclude group: "net.fabricmc.fabric-api" }
 
 	//shulkerutils
-	modImplementation 'net.kyrptonaught:shulkerutils:1.0.5-1.21.10'
-	include 'net.kyrptonaught:shulkerutils:1.0.5-1.21.10'
+	modImplementation 'net.kyrptonaught:shulkerutils:1.0.5-1.21.11'
+	include 'net.kyrptonaught:shulkerutils:1.0.5-1.21.11'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -25,14 +25,14 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation include("net.kyrptonaught:kyrptconfig:1.6.2-1.21.6") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation include("net.kyrptonaught:kyrptconfig:1.6.2-1.21.8") { exclude group: "net.fabricmc.fabric-api" }
 
 	//update modmenu when kyrptconfig is pulling old version
-	modImplementation ("com.terraformersmc:modmenu:15.0.0-beta.3") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation ("com.terraformersmc:modmenu:15.0.1") { exclude group: "net.fabricmc.fabric-api" }
 
 	//shulkerutils
-	modImplementation 'net.kyrptonaught:shulkerutils:1.0.5-1.21.6'
-	include 'net.kyrptonaught:shulkerutils:1.0.5-1.21.6'
+	modImplementation 'net.kyrptonaught:shulkerutils:1.0.5-1.21.8'
+	include 'net.kyrptonaught:shulkerutils:1.0.5-1.21.8'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -25,14 +25,14 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation include("net.kyrptonaught:kyrptconfig:1.6.1-1.21.5") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation include("net.kyrptonaught:kyrptconfig:1.6.2-1.21.6") { exclude group: "net.fabricmc.fabric-api" }
 
 	//update modmenu when kyrptconfig is pulling old version
-	modImplementation ("com.terraformersmc:modmenu:14.0.1") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation ("com.terraformersmc:modmenu:15.0.0-beta.3") { exclude group: "net.fabricmc.fabric-api" }
 
 	//shulkerutils
-	modImplementation 'net.kyrptonaught:shulkerutils:1.0.5-1.21.5'
-	include 'net.kyrptonaught:shulkerutils:1.0.5-1.21.5'
+	modImplementation 'net.kyrptonaught:shulkerutils:1.0.5-1.21.6'
+	include 'net.kyrptonaught:shulkerutils:1.0.5-1.21.6'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ repositories {
 	maven { url 'https://maven.fabricmc.net' }
 	maven { url 'https://maven.kyrptonaught.dev' }
 	maven { url "https://maven.terraformersmc.com/releases" }
-	maven { url "https://maven.nucleoid.xyz/" }
 }
 
 dependencies {
@@ -28,14 +27,14 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation include("net.kyrptonaught:kyrptconfig:1.6.0-1.20.4") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation include("net.kyrptonaught:kyrptconfig:1.6.1-1.20.5") { exclude group: "net.fabricmc.fabric-api" }
 
 	//update modmenu when kyrptconfig is pulling old version
-	modImplementation ("com.terraformersmc:modmenu:9.2.0") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation ("com.terraformersmc:modmenu:10.0.0") { exclude group: "net.fabricmc.fabric-api" }
 
 	//shulkerutils
-	modImplementation 'net.kyrptonaught:shulkerutils:1.0.5-1.20.4'
-	include 'net.kyrptonaught:shulkerutils:1.0.5-1.20.4'
+	modImplementation 'net.kyrptonaught:shulkerutils:1.0.5-1.20.5'
+	include 'net.kyrptonaught:shulkerutils:1.0.5-1.20.5'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
-minecraft_version=1.20.1
-yarn_mappings=1.20.1+build.2
-loader_version=0.14.21
+minecraft_version=1.20.2
+yarn_mappings=1.20.2+build.4
+loader_version=0.18.4
 
 #Fabric api
-fabric_version=0.83.1+1.20.1
+fabric_version=0.91.6+1.20.2
 
 # Mod Properties
-mod_version=1.4.0-1.20
+mod_version=1.4.0-1.20.2
 maven_group=net.kyrptonaught
 archives_base_name=quickshulker

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
-minecraft_version=1.20.2
-yarn_mappings=1.20.2+build.4
+minecraft_version=1.20.4
+yarn_mappings=1.20.4+build.3
 loader_version=0.18.4
 
 #Fabric api
-fabric_version=0.91.6+1.20.2
+fabric_version=0.97.3+1.20.4
 
 # Mod Properties
-mod_version=1.4.0-1.20.2
+mod_version=1.4.0-1.20.4
 maven_group=net.kyrptonaught
 archives_base_name=quickshulker

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
-minecraft_version=1.21.10
-yarn_mappings=1.21.10+build.3
+minecraft_version=1.21.11
+yarn_mappings=1.21.11+build.4
 loader_version=0.18.4
 
 #Fabric api
-fabric_version=0.138.4+1.21.10
+fabric_version=0.141.1+1.21.11
 
 # Mod Properties
 mod_version=1.4.1-1.21.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
-minecraft_version=1.21.5
-yarn_mappings=1.21.5+build.1
+minecraft_version=1.21.6
+yarn_mappings=1.21.6+build.1
 loader_version=0.18.4
 
 #Fabric api
-fabric_version=0.128.2+1.21.5
+fabric_version=0.128.2+1.21.6
 
 # Mod Properties
-mod_version=1.4.1-1.21.5
+mod_version=1.4.1-1.21.6
 maven_group=net.kyrptonaught
 archives_base_name=quickshulker

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,6 @@ loader_version=0.18.4
 fabric_version=0.141.1+1.21.11
 
 # Mod Properties
-mod_version=1.4.1-1.21.10
+mod_version=1.4.1-1.21.11
 maven_group=net.kyrptonaught
 archives_base_name=quickshulker

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
-minecraft_version=1.20.5
-yarn_mappings=1.20.5+build.1
+minecraft_version=1.21.4
+yarn_mappings=1.21.4+build.8
 loader_version=0.18.4
 
 #Fabric api
-fabric_version=0.97.8+1.20.5
+fabric_version=0.119.4+1.21.4
 
 # Mod Properties
-mod_version=1.4.1-1.20.5
+mod_version=1.4.1-1.21.4
 maven_group=net.kyrptonaught
 archives_base_name=quickshulker

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
-minecraft_version=1.21.9
-yarn_mappings=1.21.9+build.1
+minecraft_version=1.21.10
+yarn_mappings=1.21.10+build.3
 loader_version=0.18.4
 
 #Fabric api
-fabric_version=0.134.1+1.21.9
+fabric_version=0.138.4+1.21.10
 
 # Mod Properties
-mod_version=1.4.1-1.21.9
+mod_version=1.4.1-1.21.10
 maven_group=net.kyrptonaught
 archives_base_name=quickshulker

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
-minecraft_version=1.20.4
-yarn_mappings=1.20.4+build.3
+minecraft_version=1.20.5
+yarn_mappings=1.20.5+build.1
 loader_version=0.18.4
 
 #Fabric api
-fabric_version=0.97.3+1.20.4
+fabric_version=0.97.8+1.20.5
 
 # Mod Properties
-mod_version=1.4.0-1.20.4
+mod_version=1.4.1-1.20.5
 maven_group=net.kyrptonaught
 archives_base_name=quickshulker

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
-minecraft_version=1.21.8
-yarn_mappings=1.21.8+build.1
+minecraft_version=1.21.9
+yarn_mappings=1.21.9+build.1
 loader_version=0.18.4
 
 #Fabric api
-fabric_version=0.136.1+1.21.8
+fabric_version=0.134.1+1.21.9
 
 # Mod Properties
-mod_version=1.4.1-1.21.8
+mod_version=1.4.1-1.21.9
 maven_group=net.kyrptonaught
 archives_base_name=quickshulker

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
-minecraft_version=1.21.6
-yarn_mappings=1.21.6+build.1
+minecraft_version=1.21.8
+yarn_mappings=1.21.8+build.1
 loader_version=0.18.4
 
 #Fabric api
-fabric_version=0.128.2+1.21.6
+fabric_version=0.136.1+1.21.8
 
 # Mod Properties
-mod_version=1.4.1-1.21.6
+mod_version=1.4.1-1.21.8
 maven_group=net.kyrptonaught
 archives_base_name=quickshulker

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.8
+minecraft_version=1.21.5
+yarn_mappings=1.21.5+build.1
 loader_version=0.18.4
 
 #Fabric api
-fabric_version=0.119.4+1.21.4
+fabric_version=0.128.2+1.21.5
 
 # Mod Properties
-mod_version=1.4.1-1.21.4
+mod_version=1.4.1-1.21.5
 maven_group=net.kyrptonaught
 archives_base_name=quickshulker

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/net/kyrptonaught/quickshulker/QuickShulkerMod.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/QuickShulkerMod.java
@@ -43,7 +43,7 @@ public class QuickShulkerMod implements ModInitializer, RegisterQuickShulker {
                 if (QuickShulkerMod.getConfig().rightClickToOpen) {
                     if (Util.isOpenableItem(stack) && Util.canOpenInHand(stack)) {
                         if (hand == Hand.MAIN_HAND)
-                            Util.openItem(player, 0, player.getInventory().selectedSlot);
+                            Util.openItem(player, 0, player.getInventory().getSelectedSlot());
                         else Util.openItem(player, 0, PlayerInventory.OFF_HAND_SLOT);
 
                         return ActionResult.SUCCESS.withNewHandStack(stack);

--- a/src/main/java/net/kyrptonaught/quickshulker/QuickShulkerMod.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/QuickShulkerMod.java
@@ -39,7 +39,7 @@ public class QuickShulkerMod implements ModInitializer, RegisterQuickShulker {
 
         UseItemCallback.EVENT.register((player, world, hand) -> {
             ItemStack stack = player.getStackInHand(hand);
-            if (!world.isClient) {
+            if (!world.isClient()) {
                 if (QuickShulkerMod.getConfig().rightClickToOpen) {
                     if (Util.isOpenableItem(stack) && Util.canOpenInHand(stack)) {
                         if (hand == Hand.MAIN_HAND)
@@ -83,7 +83,7 @@ public class QuickShulkerMod implements ModInitializer, RegisterQuickShulker {
                     .setItem(CraftingTableBlock.class)
                     .ignoreSingleStackCheck(true)
                     .setOpenAction(((player, stack) -> player.openHandledScreen(new SimpleNamedScreenHandlerFactory((i, playerInventory, playerEntity) ->
-                            new CraftingScreenHandler(i, playerInventory, ScreenHandlerContext.create(player.getWorld(), player.getBlockPos())), Text.translatable("container.crafting")))))
+                            new CraftingScreenHandler(i, playerInventory, ScreenHandlerContext.create(player.getEntityWorld(), player.getBlockPos())), Text.translatable("container.crafting")))))
                     .register();
 
         if (getConfig().quickStonecutter)
@@ -91,7 +91,7 @@ public class QuickShulkerMod implements ModInitializer, RegisterQuickShulker {
                     .setItem(StonecutterBlock.class)
                     .ignoreSingleStackCheck(true)
                     .setOpenAction(((player, stack) -> player.openHandledScreen(new SimpleNamedScreenHandlerFactory((i, playerInventory, playerEntity) ->
-                            new StonecutterScreenHandler(i, playerInventory, ScreenHandlerContext.create(player.getWorld(), player.getBlockPos())), Text.translatable("container.stonecutter")))))
+                            new StonecutterScreenHandler(i, playerInventory, ScreenHandlerContext.create(player.getEntityWorld(), player.getBlockPos())), Text.translatable("container.stonecutter")))))
                     .register();
     }
 }

--- a/src/main/java/net/kyrptonaught/quickshulker/QuickShulkerMod.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/QuickShulkerMod.java
@@ -7,7 +7,6 @@ import net.fabricmc.loader.api.FabricLoader;
 import net.kyrptonaught.kyrptconfig.config.ConfigManager;
 import net.kyrptonaught.quickshulker.api.*;
 import net.kyrptonaught.quickshulker.config.ConfigOptions;
-import net.kyrptonaught.quickshulker.network.OpenInventoryPacket;
 import net.kyrptonaught.quickshulker.network.OpenShulkerPacket;
 import net.kyrptonaught.quickshulker.network.QuickBundlePacket;
 import net.minecraft.block.CraftingTableBlock;
@@ -19,8 +18,8 @@ import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.screen.*;
 import net.minecraft.text.Text;
+import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
-import net.minecraft.util.TypedActionResult;
 
 
 public class QuickShulkerMod implements ModInitializer, RegisterQuickShulker {
@@ -47,11 +46,11 @@ public class QuickShulkerMod implements ModInitializer, RegisterQuickShulker {
                             Util.openItem(player, 0, player.getInventory().selectedSlot);
                         else Util.openItem(player, 0, PlayerInventory.OFF_HAND_SLOT);
 
-                        return TypedActionResult.success(stack);
+                        return ActionResult.SUCCESS.withNewHandStack(stack);
                     }
                 }
             }
-            return TypedActionResult.pass(stack);
+            return ActionResult.PASS;
         });
         FabricLoader.getInstance().getEntrypoints(MOD_ID, RegisterQuickShulker.class).forEach(RegisterQuickShulker::registerProviders);
     }

--- a/src/main/java/net/kyrptonaught/quickshulker/QuickShulkerMod.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/QuickShulkerMod.java
@@ -83,7 +83,7 @@ public class QuickShulkerMod implements ModInitializer, RegisterQuickShulker {
                     .setItem(CraftingTableBlock.class)
                     .ignoreSingleStackCheck(true)
                     .setOpenAction(((player, stack) -> player.openHandledScreen(new SimpleNamedScreenHandlerFactory((i, playerInventory, playerEntity) ->
-                            new CraftingScreenHandler(i, playerInventory, ScreenHandlerContext.create(player.getEntityWorld(), player.getBlockPos())), Text.translatable("container.crafting")))))
+                            new CraftingScreenHandler(i, playerInventory, ScreenHandlerContext.create(player.getWorld(), player.getBlockPos())), Text.translatable("container.crafting")))))
                     .register();
 
         if (getConfig().quickStonecutter)
@@ -91,7 +91,7 @@ public class QuickShulkerMod implements ModInitializer, RegisterQuickShulker {
                     .setItem(StonecutterBlock.class)
                     .ignoreSingleStackCheck(true)
                     .setOpenAction(((player, stack) -> player.openHandledScreen(new SimpleNamedScreenHandlerFactory((i, playerInventory, playerEntity) ->
-                            new StonecutterScreenHandler(i, playerInventory, ScreenHandlerContext.create(player.getEntityWorld(), player.getBlockPos())), Text.translatable("container.stonecutter")))))
+                            new StonecutterScreenHandler(i, playerInventory, ScreenHandlerContext.create(player.getWorld(), player.getBlockPos())), Text.translatable("container.stonecutter")))))
                     .register();
     }
 }

--- a/src/main/java/net/kyrptonaught/quickshulker/QuickShulkerMod.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/QuickShulkerMod.java
@@ -2,16 +2,19 @@ package net.kyrptonaught.quickshulker;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.player.UseItemCallback;
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.loader.api.FabricLoader;
 import net.kyrptonaught.kyrptconfig.config.ConfigManager;
 import net.kyrptonaught.quickshulker.api.*;
 import net.kyrptonaught.quickshulker.config.ConfigOptions;
+import net.kyrptonaught.quickshulker.network.OpenInventoryPacket;
 import net.kyrptonaught.quickshulker.network.OpenShulkerPacket;
 import net.kyrptonaught.quickshulker.network.QuickBundlePacket;
 import net.minecraft.block.CraftingTableBlock;
 import net.minecraft.block.EnderChestBlock;
 import net.minecraft.block.ShulkerBoxBlock;
 import net.minecraft.block.StonecutterBlock;
+import net.minecraft.component.DataComponentTypes;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.screen.*;
@@ -28,8 +31,13 @@ public class QuickShulkerMod implements ModInitializer, RegisterQuickShulker {
     @Override
     public void onInitialize() {
         config.load();
+        PayloadTypeRegistry.playC2S().register(OpenShulkerPacket.ID, OpenShulkerPacket.CODEC);
+        PayloadTypeRegistry.playC2S().register(QuickBundlePacket.ID, QuickBundlePacket.CODEC);
+        PayloadTypeRegistry.playC2S().register(QuickBundlePacket.BundleIntoHeld.ID, QuickBundlePacket.BundleIntoHeld.CODEC);
+        PayloadTypeRegistry.playC2S().register(QuickBundlePacket.Unbundle.ID, QuickBundlePacket.Unbundle.CODEC);
         OpenShulkerPacket.registerReceivePacket();
         QuickBundlePacket.registerReceivePacket();
+
         UseItemCallback.EVENT.register((player, world, hand) -> {
             ItemStack stack = player.getStackInHand(hand);
             if (!world.isClient) {
@@ -59,7 +67,7 @@ public class QuickShulkerMod implements ModInitializer, RegisterQuickShulker {
                     .setItem(ShulkerBoxBlock.class)
                     .supportsBundleing(true)
                     .setOpenAction(((player, stack) -> player.openHandledScreen(new SimpleNamedScreenHandlerFactory((i, playerInventory, playerEntity) ->
-                            new ShulkerBoxScreenHandler(i, player.getInventory(), new ItemStackInventory(stack, 27)), stack.hasCustomName() ? stack.getName() : Text.translatable("container.shulkerBox")))))
+                            new ShulkerBoxScreenHandler(i, player.getInventory(), new ItemStackInventory(stack, 27)), stack.getComponents().contains(DataComponentTypes.CUSTOM_NAME) ? stack.getName() : Text.translatable("container.shulkerBox")))))
                     .register();
 
         if (getConfig().quickEChest)

--- a/src/main/java/net/kyrptonaught/quickshulker/api/Util.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/api/Util.java
@@ -6,7 +6,6 @@ import net.kyrptonaught.quickshulker.network.OpenInventoryPacket;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
-import net.minecraft.network.packet.s2c.play.CloseScreenS2CPacket;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.ScreenHandlerListener;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -28,7 +27,6 @@ public class Util {
             return;
         }
         ItemStack stack = player.getInventory().getStack(playerInvIndex);
-        stack.removeSubNbt(QuickShulkerMod.MOD_ID);
         QuickShulkerData qsData = QuickOpenableRegistry.getQuickie(stack.getItem());
         if (qsData != null) {
             qsData.openConsumer.accept(player, stack);

--- a/src/main/java/net/kyrptonaught/quickshulker/client/ClientUtil.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/client/ClientUtil.java
@@ -6,7 +6,6 @@ import net.kyrptonaught.quickshulker.network.OpenShulkerPacket;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.slot.Slot;

--- a/src/main/java/net/kyrptonaught/quickshulker/client/QuickShulkerModClient.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/client/QuickShulkerModClient.java
@@ -15,7 +15,9 @@ import net.kyrptonaught.quickshulker.api.RegisterQuickShulkerClient;
 import net.kyrptonaught.quickshulker.network.OpenInventoryPacket;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
+import net.minecraft.client.option.KeyBinding;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.Identifier;
 
 @Environment(EnvType.CLIENT)
 public class QuickShulkerModClient implements ClientModInitializer {
@@ -45,7 +47,7 @@ public class QuickShulkerModClient implements ClientModInitializer {
 
         KeyBindingHelper.registerKeyBinding(new DisplayOnlyKeyBind(
                 "key.quickshulker.config.keybinding",
-                "key.categories.quickshulker",
+                KeyBinding.Category.create(Identifier.of(QuickShulkerMod.MOD_ID, "key.categories.quickshulker")),
                 getKeybinding(),
                 setKey -> QuickShulkerMod.config.save()
         ));

--- a/src/main/java/net/kyrptonaught/quickshulker/client/QuickShulkerModClient.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/client/QuickShulkerModClient.java
@@ -13,8 +13,6 @@ import net.kyrptonaught.kyrptconfig.keybinding.DisplayOnlyKeyBind;
 import net.kyrptonaught.quickshulker.QuickShulkerMod;
 import net.kyrptonaught.quickshulker.api.RegisterQuickShulkerClient;
 import net.kyrptonaught.quickshulker.network.OpenInventoryPacket;
-import net.kyrptonaught.quickshulker.network.OpenShulkerPacket;
-import net.kyrptonaught.quickshulker.network.QuickBundlePacket;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
 import net.minecraft.entity.player.PlayerEntity;
@@ -31,7 +29,7 @@ public class QuickShulkerModClient implements ClientModInitializer {
                     if (player.getMainHandStack().isEmpty() && !player.getOffHandStack().isEmpty())
                         ClientUtil.CheckAndSend(player.getOffHandStack(), 45);
                     else
-                        ClientUtil.CheckAndSend(player.getMainHandStack(), 36 + player.getInventory().selectedSlot);
+                        ClientUtil.CheckAndSend(player.getMainHandStack(), 36 + player.getInventory().getSelectedSlot());
                 }
             }
         });

--- a/src/main/java/net/kyrptonaught/quickshulker/client/QuickShulkerModClient.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/client/QuickShulkerModClient.java
@@ -6,12 +6,15 @@ import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.loader.api.FabricLoader;
 import net.kyrptonaught.kyrptconfig.keybinding.CustomKeyBinding;
 import net.kyrptonaught.kyrptconfig.keybinding.DisplayOnlyKeyBind;
 import net.kyrptonaught.quickshulker.QuickShulkerMod;
 import net.kyrptonaught.quickshulker.api.RegisterQuickShulkerClient;
 import net.kyrptonaught.quickshulker.network.OpenInventoryPacket;
+import net.kyrptonaught.quickshulker.network.OpenShulkerPacket;
+import net.kyrptonaught.quickshulker.network.QuickBundlePacket;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
 import net.minecraft.entity.player.PlayerEntity;
@@ -32,10 +35,13 @@ public class QuickShulkerModClient implements ClientModInitializer {
                 }
             }
         });
-        ClientPlayNetworking.registerGlobalReceiver(OpenInventoryPacket.OPEN_INV, (client, handler, packet, sender) -> {
+        PayloadTypeRegistry.playS2C().register(OpenInventoryPacket.ID, OpenInventoryPacket.CODEC);
+        ClientPlayNetworking.registerGlobalReceiver(OpenInventoryPacket.ID, (payload, context) -> {
+            MinecraftClient client = MinecraftClient.getInstance();
             client.execute(() -> {
-                client.setScreen(new InventoryScreen(client.player));
+                client.setScreen(new InventoryScreen(context.player()));
             });
+
         });
         FabricLoader.getInstance().getEntrypoints(QuickShulkerMod.MOD_ID + "_client", RegisterQuickShulkerClient.class).forEach(RegisterQuickShulkerClient::registerClient);
 

--- a/src/main/java/net/kyrptonaught/quickshulker/mixin/ItemMixin.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/mixin/ItemMixin.java
@@ -22,7 +22,7 @@ public abstract class ItemMixin {
     @Inject(method = "onClicked", at = @At("HEAD"), cancellable = true)
     public void QS$onClicked(ItemStack hostStack, ItemStack insertStack, Slot slot, ClickType clickType, PlayerEntity player, StackReference cursorStackReference, CallbackInfoReturnable<Boolean> cir) {
         if (BundleHelper.shouldAttemptBundle(player, clickType, hostStack, insertStack, QuickShulkerMod.getConfig().supportsBundlingInsert)) {
-            if (!player.getWorld().isClient) {
+            if (!player.getEntityWorld().isClient()) {
                 BundleHelper.bundleItemIntoStack(player, hostStack, insertStack, cir);
             } else if (slot.inventory instanceof PlayerInventory && ClientUtil.isCreativeScreen(player)) {//stupid creative menu shiz
                 QuickBundlePacket.sendPacket(ClientUtil.getPlayerInvSlot(player.currentScreenHandler, slot), insertStack);
@@ -35,7 +35,7 @@ public abstract class ItemMixin {
     public void QS$onStackClicked(ItemStack hostStack, Slot slot, ClickType clickType, PlayerEntity player, CallbackInfoReturnable<Boolean> cir) {
         ItemStack insertStack = slot.getStack();
         if (BundleHelper.shouldAttemptBundle(player, clickType, hostStack, insertStack, QuickShulkerMod.getConfig().supportsBundlingPickup)) {//bundle stack into held item
-            if (!player.getWorld().isClient) {
+            if (!player.getEntityWorld().isClient()) {
                 BundleHelper.bundleItemIntoStack(player, hostStack, insertStack, cir);
             } else if (slot.inventory instanceof PlayerInventory && ClientUtil.isCreativeScreen(player)) { //stupid creative menu shiz
                 QuickBundlePacket.BundleIntoHeld.sendPacket(insertStack, hostStack);
@@ -43,7 +43,7 @@ public abstract class ItemMixin {
                 QuickBundlePacket.sendCreativeSlotUpdate(insertStack, slot);
             }
         } else if (BundleHelper.shouldAttemptUnBundle(player, clickType, hostStack, insertStack, QuickShulkerMod.getConfig().supportsBundlingExtract)) {//unbundle held stack into slot
-            if (!player.getWorld().isClient) {
+            if (!player.getEntityWorld().isClient()) {
                 BundleHelper.unbundleStackIntoSlot(player, hostStack, slot, cir);
             } else if (slot.inventory instanceof PlayerInventory && ClientUtil.isCreativeScreen(player)) { //stupid creative menu shiz
                 QuickBundlePacket.Unbundle.sendPacket(ClientUtil.getPlayerInvSlot(player.currentScreenHandler, slot), hostStack);

--- a/src/main/java/net/kyrptonaught/quickshulker/mixin/ScreenMixin.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/mixin/ScreenMixin.java
@@ -6,7 +6,9 @@ import net.kyrptonaught.quickshulker.QuickShulkerMod;
 import net.kyrptonaught.quickshulker.client.ClientUtil;
 import net.kyrptonaught.quickshulker.client.QuickShulkerModClient;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.input.KeyInput;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
@@ -44,9 +46,9 @@ public abstract class ScreenMixin {
     }
 
     @Inject(method = "keyPressed", at = @At("HEAD"), cancellable = true)
-    private void QS$keyPressed(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
+    private void QS$keyPressed(KeyInput input, CallbackInfoReturnable<Boolean> cir) {
         if (QuickShulkerMod.getConfig().keybingInInv) {
-            if (QuickShulkerModClient.getKeybinding().matches(keyCode, InputUtil.Type.KEYSYM)) {
+            if (QuickShulkerModClient.getKeybinding().matches(input.key(), InputUtil.Type.KEYSYM)) {
                 if (handleTrigger())
                     cir.setReturnValue(true);
             }
@@ -54,9 +56,9 @@ public abstract class ScreenMixin {
     }
 
     @Inject(method = "mouseClicked", at = @At("HEAD"), cancellable = true)
-    private void QS$mousePressed(double mouseX, double mouseY, int button, CallbackInfoReturnable<Boolean> cir) {
+    private void QS$mousePressed(Click click, boolean doubled, CallbackInfoReturnable<Boolean> cir) {
         if (QuickShulkerMod.getConfig().rightClickInv) {
-            if (this.handler.getCursorStack().isEmpty() && button == 1 && this.focusedSlot != null && this.focusedSlot.getStack().getCount() == 1) {
+            if (this.handler.getCursorStack().isEmpty() && click.button() == 1 && this.focusedSlot != null && this.focusedSlot.getStack().getCount() == 1) {
                 if (handleTrigger()) {
                     this.cancelNextRelease = true;
                     cir.setReturnValue(true);
@@ -65,7 +67,7 @@ public abstract class ScreenMixin {
             }
         }
         if (QuickShulkerMod.getConfig().keybingInInv) {
-            if (QuickShulkerModClient.getKeybinding().matches(button, InputUtil.Type.MOUSE)) {
+            if (QuickShulkerModClient.getKeybinding().matches(click.button(), InputUtil.Type.MOUSE)) {
                 if (handleTrigger()) {
                     this.cancelNextRelease = true;
                     cir.setReturnValue(true);

--- a/src/main/java/net/kyrptonaught/quickshulker/network/OpenInventoryPacket.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/network/OpenInventoryPacket.java
@@ -1,17 +1,24 @@
 package net.kyrptonaught.quickshulker.network;
 
-import io.netty.buffer.Unpooled;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.kyrptonaught.quickshulker.QuickShulkerMod;
-import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 
-public class OpenInventoryPacket {
-    public static final Identifier OPEN_INV = new Identifier(QuickShulkerMod.MOD_ID, "openinv");
+public class OpenInventoryPacket implements CustomPayload {
+    public static final CustomPayload.Id<OpenInventoryPacket> ID = new CustomPayload.Id<>(new Identifier(QuickShulkerMod.MOD_ID, "openinv"));
+    public static final PacketCodec<RegistryByteBuf, OpenInventoryPacket> CODEC
+            = PacketCodec.ofStatic((buf, value) -> {}, buf -> new OpenInventoryPacket());
 
     public static void send(ServerPlayerEntity player) {
-        ServerPlayNetworking.send(player, OPEN_INV, new PacketByteBuf(Unpooled.buffer()));
+        ServerPlayNetworking.send(player, new OpenInventoryPacket());
     }
 
+    @Override
+    public Id<? extends CustomPayload> getId() {
+        return ID;
+    }
 }

--- a/src/main/java/net/kyrptonaught/quickshulker/network/OpenInventoryPacket.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/network/OpenInventoryPacket.java
@@ -9,7 +9,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 
 public class OpenInventoryPacket implements CustomPayload {
-    public static final CustomPayload.Id<OpenInventoryPacket> ID = new CustomPayload.Id<>(new Identifier(QuickShulkerMod.MOD_ID, "openinv"));
+    public static final CustomPayload.Id<OpenInventoryPacket> ID = new CustomPayload.Id<>(Identifier.of(QuickShulkerMod.MOD_ID, "openinv"));
     public static final PacketCodec<RegistryByteBuf, OpenInventoryPacket> CODEC
             = PacketCodec.ofStatic((buf, value) -> {}, buf -> new OpenInventoryPacket());
 

--- a/src/main/java/net/kyrptonaught/quickshulker/network/OpenShulkerPacket.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/network/OpenShulkerPacket.java
@@ -14,7 +14,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.Identifier;
 
 public record OpenShulkerPacket(int invSlot) implements CustomPayload {
-    public static final Id<OpenShulkerPacket> ID = new Id<>(new Identifier(QuickShulkerMod.MOD_ID, "open_shulker_packet"));
+    public static final Id<OpenShulkerPacket> ID = new Id<>(Identifier.of(QuickShulkerMod.MOD_ID, "open_shulker_packet"));
     public static final PacketCodec<RegistryByteBuf, OpenShulkerPacket> CODEC
             = PacketCodecs.VAR_INT.xmap(OpenShulkerPacket::new, OpenShulkerPacket::invSlot).cast();
 

--- a/src/main/java/net/kyrptonaught/quickshulker/network/OpenShulkerPacket.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/network/OpenShulkerPacket.java
@@ -1,29 +1,41 @@
 package net.kyrptonaught.quickshulker.network;
 
-import io.netty.buffer.Unpooled;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.kyrptonaught.quickshulker.QuickShulkerMod;
 import net.kyrptonaught.quickshulker.api.Util;
-import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
+import net.minecraft.network.packet.CustomPayload;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.Identifier;
 
-public class OpenShulkerPacket {
-    private static final Identifier OPEN_SHULKER_PACKET = new Identifier(QuickShulkerMod.MOD_ID, "open_shulker_packet");
+public record OpenShulkerPacket(int invSlot) implements CustomPayload {
+    public static final Id<OpenShulkerPacket> ID = new Id<>(new Identifier(QuickShulkerMod.MOD_ID, "open_shulker_packet"));
+    public static final PacketCodec<RegistryByteBuf, OpenShulkerPacket> CODEC
+            = PacketCodecs.VAR_INT.xmap(OpenShulkerPacket::new, OpenShulkerPacket::invSlot).cast();
+
 
     public static void registerReceivePacket() {
-        ServerPlayNetworking.registerGlobalReceiver(OPEN_SHULKER_PACKET, (server, player, serverPlayNetworkHandler, packetByteBuf, packetSender) -> {
-            int invSlot = packetByteBuf.readInt();
-            server.execute(() -> Util.openItem(player, invSlot));
+        ServerPlayNetworking.registerGlobalReceiver(ID, (payload, context) -> {
+            MinecraftServer server = context.player().server;
+            int invSlot = payload.invSlot();
+            server.execute(() -> Util.openItem(context.player(), invSlot));
         });
     }
 
     @Environment(EnvType.CLIENT)
     public static void sendOpenPacket(int invSlot) {
-        PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
-        buf.writeInt(invSlot);
-        ClientPlayNetworking.send(OPEN_SHULKER_PACKET, new PacketByteBuf(buf));
+        ClientPlayNetworking.send(new OpenShulkerPacket(invSlot));
     }
+
+    @Override
+    public Id<? extends CustomPayload> getId() {
+        return ID;
+    }
+
+
 }

--- a/src/main/java/net/kyrptonaught/quickshulker/network/OpenShulkerPacket.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/network/OpenShulkerPacket.java
@@ -21,7 +21,7 @@ public record OpenShulkerPacket(int invSlot) implements CustomPayload {
 
     public static void registerReceivePacket() {
         ServerPlayNetworking.registerGlobalReceiver(ID, (payload, context) -> {
-            MinecraftServer server = context.player().getServer();
+            MinecraftServer server = context.server();
             int invSlot = payload.invSlot();
             server.execute(() -> Util.openItem(context.player(), invSlot));
         });

--- a/src/main/java/net/kyrptonaught/quickshulker/network/OpenShulkerPacket.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/network/OpenShulkerPacket.java
@@ -21,7 +21,7 @@ public record OpenShulkerPacket(int invSlot) implements CustomPayload {
 
     public static void registerReceivePacket() {
         ServerPlayNetworking.registerGlobalReceiver(ID, (payload, context) -> {
-            MinecraftServer server = context.player().server;
+            MinecraftServer server = context.player().getServer();
             int invSlot = payload.invSlot();
             server.execute(() -> Util.openItem(context.player(), invSlot));
         });

--- a/src/main/java/net/kyrptonaught/quickshulker/network/QuickBundlePacket.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/network/QuickBundlePacket.java
@@ -26,7 +26,7 @@ public record QuickBundlePacket(int invSlotId, ItemStack stackToBundle) implemen
     public static void registerReceivePacket() {
         ServerPlayNetworking.registerGlobalReceiver(ID, (payload, context) -> {
             if (context.player().isCreative()) {
-                context.player().getServer().execute(() -> BundleHelper.bundleItemIntoStack(context.player(), context.player().getInventory().getStack(payload.invSlotId()), payload.stackToBundle(), null));
+                context.server().execute(() -> BundleHelper.bundleItemIntoStack(context.player(), context.player().getInventory().getStack(payload.invSlotId()), payload.stackToBundle(), null));
             }
         });
         Unbundle.registerReceivePacket();
@@ -58,7 +58,7 @@ public record QuickBundlePacket(int invSlotId, ItemStack stackToBundle) implemen
         public static void registerReceivePacket() {
             ServerPlayNetworking.registerGlobalReceiver(BundleIntoHeld.ID, (payload, context) -> {
                 if (context.player().isCreative()) {
-                    context.player().getServer().execute(() -> BundleHelper.bundleItemIntoStack(context.player(), payload.bundleStack(), payload.stackToBundle(), null));
+                    context.server().execute(() -> BundleHelper.bundleItemIntoStack(context.player(), payload.bundleStack(), payload.stackToBundle(), null));
                 }
             });
         }
@@ -85,7 +85,7 @@ public record QuickBundlePacket(int invSlotId, ItemStack stackToBundle) implemen
         public static void registerReceivePacket() {
             ServerPlayNetworking.registerGlobalReceiver(Unbundle.ID, (payload, context) -> {
                 if (context.player().isCreative()) {
-                    context.player().getServer().execute(() -> {
+                    context.server().execute(() -> {
                         ItemStack output = BundleHelper.unbundleItem(context.player(), payload.unbundleStack());
                         if (output != null)
                             context.player().getInventory().setStack(payload.invSlotId(), output);

--- a/src/main/java/net/kyrptonaught/quickshulker/network/QuickBundlePacket.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/network/QuickBundlePacket.java
@@ -1,6 +1,5 @@
 package net.kyrptonaught.quickshulker.network;
 
-import io.netty.buffer.Unpooled;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
@@ -9,21 +8,25 @@ import net.kyrptonaught.quickshulker.BundleHelper;
 import net.kyrptonaught.quickshulker.QuickShulkerMod;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.item.ItemStack;
-import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
+import net.minecraft.network.packet.CustomPayload;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.util.Identifier;
 
-public class QuickBundlePacket {
-    private static final Identifier QUICK_BUNDLE_PACKET = new Identifier(QuickShulkerMod.MOD_ID, "quick_bundle_packet");
-    private static final Identifier QUICK_BUNDLEHELD_PACKET = new Identifier(QuickShulkerMod.MOD_ID, "quick_bundleheld_packet");
-    private static final Identifier QUICK_UNBUNDLE_PACKET = new Identifier(QuickShulkerMod.MOD_ID, "quick_unbundle_packet");
+public record QuickBundlePacket(int invSlotId, ItemStack stackToBundle) implements CustomPayload {
+    public static final CustomPayload.Id<QuickBundlePacket> ID = new CustomPayload.Id<>(new Identifier(QuickShulkerMod.MOD_ID, "quick_bundle_packet"));
+    public static final PacketCodec<RegistryByteBuf, QuickBundlePacket> CODEC
+            = PacketCodec.tuple(
+            PacketCodecs.VAR_INT, QuickBundlePacket::invSlotId,
+            ItemStack.PACKET_CODEC, QuickBundlePacket::stackToBundle,
+            QuickBundlePacket::new);
 
     public static void registerReceivePacket() {
-        ServerPlayNetworking.registerGlobalReceiver(QUICK_BUNDLE_PACKET, (server, player, serverPlayNetworkHandler, packetByteBuf, packetSender) -> {
-            if (player.isCreative()) {
-                int playerInvSlotID = packetByteBuf.readInt();
-                ItemStack stackToBundle = packetByteBuf.readItemStack();
-                server.execute(() -> BundleHelper.bundleItemIntoStack(player, player.getInventory().getStack(playerInvSlotID), stackToBundle, null));
+        ServerPlayNetworking.registerGlobalReceiver(ID, (payload, context) -> {
+            if (context.player().isCreative()) {
+                context.player().server.execute(() -> BundleHelper.bundleItemIntoStack(context.player(), context.player().getInventory().getStack(payload.invSlotId()), payload.stackToBundle(), null));
             }
         });
         Unbundle.registerReceivePacket();
@@ -32,46 +35,60 @@ public class QuickBundlePacket {
 
     @Environment(EnvType.CLIENT)
     public static void sendPacket(int slotID, ItemStack stackToBundle) {
-        PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
-        buf.writeInt(slotID);
-        buf.writeItemStack(stackToBundle);
-        ClientPlayNetworking.send(QUICK_BUNDLE_PACKET, new PacketByteBuf(buf));
+        ClientPlayNetworking.send(new QuickBundlePacket(slotID, stackToBundle.copy()));
     }
 
     public static void sendCreativeSlotUpdate(ItemStack output, Slot slot) {
         MinecraftClient.getInstance().interactionManager.clickCreativeStack(output, slot.id);
     }
 
-    public static class BundleIntoHeld {
+    @Override
+    public Id<? extends CustomPayload> getId() {
+        return ID;
+    }
+
+    public record BundleIntoHeld(ItemStack stackToBundle, ItemStack bundleStack) implements CustomPayload {
+        public static final CustomPayload.Id<BundleIntoHeld> ID = new CustomPayload.Id<>(new Identifier(QuickShulkerMod.MOD_ID, "quick_bundleheld_packet"));
+        public static final PacketCodec<RegistryByteBuf, BundleIntoHeld> CODEC
+                = PacketCodec.tuple(
+                ItemStack.PACKET_CODEC, BundleIntoHeld::stackToBundle,
+                ItemStack.PACKET_CODEC, BundleIntoHeld::bundleStack,
+                BundleIntoHeld::new);
+
         public static void registerReceivePacket() {
-            ServerPlayNetworking.registerGlobalReceiver(QUICK_BUNDLEHELD_PACKET, (server, player, serverPlayNetworkHandler, packetByteBuf, packetSender) -> {
-                if (player.isCreative()) {
-                    ItemStack stackToBundle = packetByteBuf.readItemStack();
-                    ItemStack bundleStack = packetByteBuf.readItemStack();
-                    server.execute(() -> BundleHelper.bundleItemIntoStack(player, bundleStack, stackToBundle, null));
+            ServerPlayNetworking.registerGlobalReceiver(BundleIntoHeld.ID, (payload, context) -> {
+                if (context.player().isCreative()) {
+                    context.player().server.execute(() -> BundleHelper.bundleItemIntoStack(context.player(), payload.bundleStack(), payload.stackToBundle(), null));
                 }
             });
         }
 
         @Environment(EnvType.CLIENT)
         public static void sendPacket(ItemStack stackToBundle, ItemStack bundleStack) {
-            PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
-            buf.writeItemStack(stackToBundle);
-            buf.writeItemStack(bundleStack);
-            ClientPlayNetworking.send(QUICK_BUNDLEHELD_PACKET, new PacketByteBuf(buf));
+            ClientPlayNetworking.send(new BundleIntoHeld(stackToBundle.copy(), bundleStack.copy()));
+        }
+
+        @Override
+        public Id<? extends CustomPayload> getId() {
+            return BundleIntoHeld.ID;
         }
     }
 
-    public static class Unbundle {
+    public record Unbundle(int invSlotId, ItemStack unbundleStack) implements CustomPayload {
+        public static final CustomPayload.Id<Unbundle> ID = new CustomPayload.Id<>(new Identifier(QuickShulkerMod.MOD_ID, "quick_unbundle_packet"));
+        public static final PacketCodec<RegistryByteBuf, Unbundle> CODEC
+                = PacketCodec.tuple(
+                PacketCodecs.VAR_INT, Unbundle::invSlotId,
+                ItemStack.PACKET_CODEC, Unbundle::unbundleStack,
+                Unbundle::new);
+
         public static void registerReceivePacket() {
-            ServerPlayNetworking.registerGlobalReceiver(QUICK_UNBUNDLE_PACKET, (server, player, serverPlayNetworkHandler, packetByteBuf, packetSender) -> {
-                if (player.isCreative()) {
-                    int playerInvSlotID = packetByteBuf.readInt();
-                    ItemStack unbundleStack = packetByteBuf.readItemStack();
-                    server.execute(() -> {
-                        ItemStack output = BundleHelper.unbundleItem(player, unbundleStack);
+            ServerPlayNetworking.registerGlobalReceiver(Unbundle.ID, (payload, context) -> {
+                if (context.player().isCreative()) {
+                    context.player().server.execute(() -> {
+                        ItemStack output = BundleHelper.unbundleItem(context.player(), payload.unbundleStack());
                         if (output != null)
-                            player.getInventory().setStack(playerInvSlotID, output);
+                            context.player().getInventory().setStack(payload.invSlotId(), output);
                     });
                 }
             });
@@ -79,10 +96,12 @@ public class QuickBundlePacket {
 
         @Environment(EnvType.CLIENT)
         public static void sendPacket(int slotID, ItemStack unbundleStack) {
-            PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
-            buf.writeInt(slotID);
-            buf.writeItemStack(unbundleStack);
-            ClientPlayNetworking.send(QUICK_UNBUNDLE_PACKET, new PacketByteBuf(buf));
+            ClientPlayNetworking.send(new Unbundle(slotID, unbundleStack.copy()));
+        }
+
+        @Override
+        public Id<? extends CustomPayload> getId() {
+            return Unbundle.ID;
         }
     }
 }

--- a/src/main/java/net/kyrptonaught/quickshulker/network/QuickBundlePacket.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/network/QuickBundlePacket.java
@@ -16,7 +16,7 @@ import net.minecraft.screen.slot.Slot;
 import net.minecraft.util.Identifier;
 
 public record QuickBundlePacket(int invSlotId, ItemStack stackToBundle) implements CustomPayload {
-    public static final CustomPayload.Id<QuickBundlePacket> ID = new CustomPayload.Id<>(new Identifier(QuickShulkerMod.MOD_ID, "quick_bundle_packet"));
+    public static final CustomPayload.Id<QuickBundlePacket> ID = new CustomPayload.Id<>(Identifier.of(QuickShulkerMod.MOD_ID, "quick_bundle_packet"));
     public static final PacketCodec<RegistryByteBuf, QuickBundlePacket> CODEC
             = PacketCodec.tuple(
             PacketCodecs.VAR_INT, QuickBundlePacket::invSlotId,
@@ -48,7 +48,7 @@ public record QuickBundlePacket(int invSlotId, ItemStack stackToBundle) implemen
     }
 
     public record BundleIntoHeld(ItemStack stackToBundle, ItemStack bundleStack) implements CustomPayload {
-        public static final CustomPayload.Id<BundleIntoHeld> ID = new CustomPayload.Id<>(new Identifier(QuickShulkerMod.MOD_ID, "quick_bundleheld_packet"));
+        public static final CustomPayload.Id<BundleIntoHeld> ID = new CustomPayload.Id<>(Identifier.of(QuickShulkerMod.MOD_ID, "quick_bundleheld_packet"));
         public static final PacketCodec<RegistryByteBuf, BundleIntoHeld> CODEC
                 = PacketCodec.tuple(
                 ItemStack.PACKET_CODEC, BundleIntoHeld::stackToBundle,
@@ -75,7 +75,7 @@ public record QuickBundlePacket(int invSlotId, ItemStack stackToBundle) implemen
     }
 
     public record Unbundle(int invSlotId, ItemStack unbundleStack) implements CustomPayload {
-        public static final CustomPayload.Id<Unbundle> ID = new CustomPayload.Id<>(new Identifier(QuickShulkerMod.MOD_ID, "quick_unbundle_packet"));
+        public static final CustomPayload.Id<Unbundle> ID = new CustomPayload.Id<>(Identifier.of(QuickShulkerMod.MOD_ID, "quick_unbundle_packet"));
         public static final PacketCodec<RegistryByteBuf, Unbundle> CODEC
                 = PacketCodec.tuple(
                 PacketCodecs.VAR_INT, Unbundle::invSlotId,

--- a/src/main/java/net/kyrptonaught/quickshulker/network/QuickBundlePacket.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/network/QuickBundlePacket.java
@@ -26,7 +26,7 @@ public record QuickBundlePacket(int invSlotId, ItemStack stackToBundle) implemen
     public static void registerReceivePacket() {
         ServerPlayNetworking.registerGlobalReceiver(ID, (payload, context) -> {
             if (context.player().isCreative()) {
-                context.player().server.execute(() -> BundleHelper.bundleItemIntoStack(context.player(), context.player().getInventory().getStack(payload.invSlotId()), payload.stackToBundle(), null));
+                context.player().getServer().execute(() -> BundleHelper.bundleItemIntoStack(context.player(), context.player().getInventory().getStack(payload.invSlotId()), payload.stackToBundle(), null));
             }
         });
         Unbundle.registerReceivePacket();
@@ -58,7 +58,7 @@ public record QuickBundlePacket(int invSlotId, ItemStack stackToBundle) implemen
         public static void registerReceivePacket() {
             ServerPlayNetworking.registerGlobalReceiver(BundleIntoHeld.ID, (payload, context) -> {
                 if (context.player().isCreative()) {
-                    context.player().server.execute(() -> BundleHelper.bundleItemIntoStack(context.player(), payload.bundleStack(), payload.stackToBundle(), null));
+                    context.player().getServer().execute(() -> BundleHelper.bundleItemIntoStack(context.player(), payload.bundleStack(), payload.stackToBundle(), null));
                 }
             });
         }
@@ -85,7 +85,7 @@ public record QuickBundlePacket(int invSlotId, ItemStack stackToBundle) implemen
         public static void registerReceivePacket() {
             ServerPlayNetworking.registerGlobalReceiver(Unbundle.ID, (payload, context) -> {
                 if (context.player().isCreative()) {
-                    context.player().server.execute(() -> {
+                    context.player().getServer().execute(() -> {
                         ItemStack output = BundleHelper.unbundleItem(context.player(), payload.unbundleStack());
                         if (output != null)
                             context.player().getInventory().setStack(payload.invSlotId(), output);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "quickshulker",
-  "version": "1.4.0-1.20.2",
+  "version": "1.4.0-1.20.4",
   "name": "Quick Shulker",
   "description": "Quickly open Shulker boxes and more",
   "authors": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "quickshulker",
-  "version": "1.4.1-1.20.5",
+  "version": "1.4.1-1.21.4",
   "name": "Quick Shulker",
   "description": "Quickly open Shulker boxes and more",
   "authors": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "quickshulker",
-  "version": "1.4.1-1.21.9",
+  "version": "1.4.1-1.21.10",
   "name": "Quick Shulker",
   "description": "Quickly open Shulker boxes and more",
   "authors": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "quickshulker",
-  "version": "1.4.1-1.21.8",
+  "version": "1.4.1-1.21.9",
   "name": "Quick Shulker",
   "description": "Quickly open Shulker boxes and more",
   "authors": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "quickshulker",
-  "version": "1.4.1-1.21.10",
+  "version": "1.4.1-1.21.11",
   "name": "Quick Shulker",
   "description": "Quickly open Shulker boxes and more",
   "authors": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "quickshulker",
-  "version": "1.4.1-1.21.6",
+  "version": "1.4.1-1.21.8",
   "name": "Quick Shulker",
   "description": "Quickly open Shulker boxes and more",
   "authors": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "quickshulker",
-  "version": "1.4.0-1.20.4",
+  "version": "1.4.1-1.20.5",
   "name": "Quick Shulker",
   "description": "Quickly open Shulker boxes and more",
   "authors": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "quickshulker",
-  "version": "1.4.1-1.21.4",
+  "version": "1.4.1-1.21.5",
   "name": "Quick Shulker",
   "description": "Quickly open Shulker boxes and more",
   "authors": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "quickshulker",
-  "version": "1.4.0-1.20",
+  "version": "1.4.0-1.20.2",
   "name": "Quick Shulker",
   "description": "Quickly open Shulker boxes and more",
   "authors": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "quickshulker",
-  "version": "1.4.1-1.21.5",
+  "version": "1.4.1-1.21.6",
   "name": "Quick Shulker",
   "description": "Quickly open Shulker boxes and more",
   "authors": [


### PR DESCRIPTION
All commits were tested, but only 1.21.11 was thoroughly tested.

Branch to migrate to Mojang official mappings once this PR is merged: https://github.com/PrivacyPolicy/quickshulker/tree/1.21-mojang-mappings

## Vanilla Bundle Changes
Since the bundle was introduced, some of the behaviors have changed, which quickshulker may need to be updated to match. Namely, inserting a stack into a held bundle uses left click, whereas quickshulker uses right click. Branch https://github.com/PrivacyPolicy/quickshulker/tree/1.21.11-insert-mouse-button-toggle adds a config to address this. I plan to open a PR for it after this one is merged.